### PR TITLE
Healing HTML

### DIFF
--- a/src/PrintMyBlog/controllers/PmbFrontend.php
+++ b/src/PrintMyBlog/controllers/PmbFrontend.php
@@ -35,13 +35,36 @@ class PmbFrontend extends BaseController
     public function addPrintButton($content)
     {
         global $post;
+
         if ($post->post_type === 'post' && is_single() && ! post_password_required($post)) {
             $print_settings = new FrontendPrintSettings();
             $print_settings->load();
             if ($print_settings->showButtons()) {
-                //phpcs:disable Generic.Files.LineLength.TooLong
-                $base_url = site_url() . "?post-type=post&include-private-posts=1&show_site_title=1&show_site_tagline=1&show_site_url=1&show_date_printed=1&show_title=1&show_date=1&show_categories=1&show_featured_image=1&show_content=1&post-page-break=on&columns=1&font-size=normal&image-size=medium&links=include&rendering-wait=10&print-my-blog=1&format=%s&pmb-post=%d";
-                //phpcs:enable
+                $base_url = add_query_arg(
+                    array(
+                        'post-type' => 'post',
+                        'include-private-posts' => '1',
+                        'show_site_title' => '1',
+                        'show_site_tagline' => '1',
+                        'show_site_url' => '1',
+                        'show_date_printed' => '1',
+                        'show_title' => '1',
+                        'show_date' => '1',
+                        'show_categories' => '1',
+                        'show_featured_image' => '1',
+                        'show_content' => '1',
+                        'post-page-break' => 'on',
+                        'columns' => '1',
+                        'font-size' => 'normal',
+                        'image-size' => 'medium',
+                        'links' => 'include',
+                        'rendering-wait' => '10',
+                        'print-my-blog' => '1',
+                        'format' => '%s',
+                        'pmb-post' => '%d',
+                    ),
+                    site_url()
+                );
                 $html = '<div class="pmb-print-this-page wp-block-button">';
                 foreach ($print_settings->formats() as $slug => $settings) {
                     if (! $print_settings->isActive($slug)) {
@@ -52,11 +75,11 @@ class PmbFrontend extends BaseController
                         $slug,
                         $post->ID
                     );
-                    $html .= ' <a href="'
-                        . $url
-                        . '" class="button button-secondary wp-block-button__link">'
-                        . $print_settings->getFrontendLabel($slug)
-                        . '</a>';
+                    $html .= sprinf(
+                        ' <a href="%s" class="button button-secondary wp-block-button__link">%s</a>',
+                        esc_url($url),
+                        esc_html($print_settings->getFrontendLabel($slug))
+                    );
                 }
                 $html .= '</div>';
                 return $html . $content;
@@ -96,6 +119,7 @@ class PmbFrontend extends BaseController
                    $pmb_format,
                    $pmb_browser,
                    $pmb_author;
+
             $pmb_site_url = str_replace(
                 array(
                     'https://',


### PR DESCRIPTION
Fixes #53 

Please consider

- avoiding if+for as building blocks https://www.youtube.com/watch?v=crSUWtRYw-M
- naming things currently named generally, e.g. `$data` or value, return, output
- converting data between languages, e.g. in PHP->HTML use esc_* functions, in string->URL use add_query_arg
- [avoiding patterns](https://github.com/object-calisthenics/phpcs-calisthenics-rules#2-do-not-use-else-keyword) like: [if() return else return](https://github.com/jupeter/clean-code-php#avoid-nesting-too-deeply-and-return-early-part-1)

Building HTML in PHP: https://github.com/szepeviktor/Toolkit4WP/blob/master/src/helpers.php#L17-L28
...in a professional way: https://github.com/decodelabs/tagged