### PR TITLE
added filter for old multisite fix

### DIFF
--- a/printmyblog.php
+++ b/printmyblog.php
@@ -9,7 +9,7 @@
  * Description: Make printing your blog easy and impressive. For you & your visitors. One post or thousands.
  * Author: Michael Nelson
  * Author URI: https://printmy.blog
- * Version: 3.27.7
+ * Version: 3.27.8-beta
  * Requires at least: 4.7
  * Requires PHP: 5.4
  * Text Domain: print-my-blog
@@ -122,7 +122,7 @@ version_compare(
     add_action('admin_notices', 'pmb_minimum_wp_version_error', 1, 0);
 } else {
     // it's all good! start bootstraping PMB.
-    define('PMB_VERSION', '3.27.7');
+    define('PMB_VERSION', '3.27.8-beta');
     define('PMB_DIR', wp_normalize_path(__DIR__) . '/');
     define('PMB_MAIN_FILE', __FILE__);
     define('PMB_TEMPLATES_DIR', PMB_DIR . 'templates/');

--- a/readme.txt
+++ b/readme.txt
@@ -459,6 +459,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 
+= 3.27.8 xxxx =
+* Enhancement: for Pro Print, added a filter for the project's print page
+
 = 3.27.7 April 24, 2025 =
 * Compatibility: hide related posts from Related Post by PickPlugins
 

--- a/src/PrintMyBlog/entities/ProjectGeneration.php
+++ b/src/PrintMyBlog/entities/ProjectGeneration.php
@@ -168,7 +168,7 @@ class ProjectGeneration
     }
 
     /**
-     * Gets the URL of the intermediary file
+     * Gets the URL of the intermediary file ("Pro Print Page")
      * @return string
      */
     public function getGeneratedIntermediaryFileUrl()
@@ -179,8 +179,12 @@ class ProjectGeneration
         } else {
             $start = $upload_dir_info['baseurl'];
         }
-        return $start . '/pmb/generated/' . $this->project->code() . '/' . $this->format->slug()
-            . '/' . rawurlencode($this->getFileName()) . '.html?uniqueness=' . current_time('timestamp');
+        return apply_filters(
+            '\PrintMyBlog\entities\ProjectGeneration::getGeneratedIntermediaryFileUrl return',
+            $start . '/pmb/generated/' . $this->project->code() . '/' . $this->format->slug()
+            . '/' . rawurlencode($this->getFileName()) . '.html?uniqueness=' . current_time('timestamp'),
+            $this
+        );
     }
 
     /**

--- a/templates/project_edit_generate.php
+++ b/templates/project_edit_generate.php
@@ -129,6 +129,7 @@ foreach($generations as $generation){
         <?php
         ?>
         <div class="pmb-after-generation" style="display:none">
+
             <button class="button button-primary" href="<?php echo esc_attr($generation->getGeneratedIntermediaryFileUrl());?>"><?php printf(__('View %s Print Page', 'print-my-blog'), $generation->getFormat()->title());?></button>
         </div>
     </div>


### PR DESCRIPTION
Mostly just adds a filter that works with https://github.com/mnelson4/print-my-blog-old-multisite-fix to fix the issue on a mulitisite install where the print page is getting created but can't be found. We think it's a misconfiguration on the user's site, but adding a filter so we can fix this just for them is probably easier for everyone.

I've asked the affected user to test it out and confirm it works before releasing.