### PR TITLE
Improve epub image css

### DIFF
--- a/designs/epub/classic/assets/style.css
+++ b/designs/epub/classic/assets/style.css
@@ -28,9 +28,20 @@ h4{
 h5{
     font-size:1.2em;
 }
-figure{
-    max-height:100vh;
+figure {
+  margin: 1em 0;
+  text-align: center;
+  max-height: none;
 }
+
+img {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  margin: 0 auto;
+}
+
 tr{
     border-top:1px solid lightgray;
 }

--- a/designs/epub/classic/assets/style.css
+++ b/designs/epub/classic/assets/style.css
@@ -36,7 +36,6 @@ figure {
 
 img {
   display: block;
-  width: 100%;
   max-width: 100%;
   height: auto;
   margin: 0 auto;

--- a/readme.txt
+++ b/readme.txt
@@ -461,6 +461,10 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 8. Pro Print digital PDF using Buurma Whitepaper design. The design adds a background color with a gradient, and a custom logo behind the page number. Designers can use the full power of HTML and CSS in their PDF designs!
 
 == Changelog ==
+= 3.27.15 April 4, 2026 =
+* Bugfix: Improved CSS rules for rendering images in the ePub design. 
+* Enhancement: Added a Design Development helper function for adding featured image thumbnails to TOC.
+
 = 3.27.14 March 19, 2026 =
 * Enhancement: Updated Freemius to version 2.13.0.
 


### PR DESCRIPTION
## Issue

closes #440 

## Overview of Changes

- Added/modified some CSS rules related to img and figure elements to improve rendering of images in ePub files using the default ePub Design. 

## Notes

- The CSS property max-height: 100vh does not work as expected in ePub files. 